### PR TITLE
Request report

### DIFF
--- a/src/Servant/Common/Req.hs
+++ b/src/Servant/Common/Req.hs
@@ -37,44 +37,33 @@ import Reflex.Dom
 
 import Web.HttpApiData
 
-data ReqResult e a = ResponseSuccess a XhrResponse
-                   | ResponseFailure String XhrResponse
-                   | RequestFailure e
+data ReqResult a = ResponseSuccess a XhrResponse
+                 | ResponseFailure String XhrResponse
+                 | RequestFailure String
 
--- data ServantError
---   = FailureResponse
---     { responseStatus            :: Status
---     , responseContentType       :: MediaType
---     , responseBody              :: ByteString
---     }
---   | DecodeFailure
---     { decodeError               :: String
---     , responseContentType       :: MediaType
---     , responseBody              :: ByteString
---     }
---   | UnsupportedContentType
---     { responseContentType       :: MediaType
---     , responseBody              :: ByteString
---     }
---   | InvalidContentTypeHeader
---     { responseContentTypeHeader :: ByteString
---     , responseBody              :: ByteString
---     }
---   | ConnectionError
---     { connectionError           :: SomeException
---     }
---   deriving (Show, Typeable)
+reqSuccess :: ReqResult a -> Maybe a
+reqSuccess (ResponseSuccess x _) = Just x
+reqSuccess _                     = Nothing
 
--- instance Exception ServantError
+reqFailure :: ReqResult a -> Maybe String
+reqFailure (ResponseFailure s _) = Just s
+reqFailure (RequestFailure s)    = Just s
+reqFailure _                     = Nothing
 
-data QueryPart t = QueryPartParam (Behavior t [String])
-                 | QueryPartFlag  (Behavior t Bool)
+response :: ReqResult a -> Maybe XhrResponse
+response (ResponseSuccess _ x) = Just x
+response (ResponseFailure _ x) = Just x
+response _                     = Nothing
+
+data QueryPart t = QueryPartParam  (Behavior t (Either String String))
+                 | QueryPartParams (Behavior t [String])
+                 | QueryPartFlag   (Behavior t Bool)
 
 data Req t = Req
   { reqMethod    :: String
-  , reqPathParts :: [Behavior t (Maybe String)]
+  , reqPathParts :: [Behavior t (Either String String)]
   , qParams      :: [(String, QueryPart t)]
-  , reqBody      :: Maybe (Behavior t (Maybe (BL.ByteString, String)))
+  , reqBody      :: Maybe (Behavior t (Either String (BL.ByteString, String)))
   -- , reqAccept    :: [MediaType]  -- TODO ?
   , headers      :: [(String, Behavior t String)]
   }
@@ -82,11 +71,11 @@ data Req t = Req
 defReq :: Reflex t => Req t
 defReq = Req "GET" [] [] Nothing []
 
-prependToPathParts :: Reflex t => Behavior t (Maybe String) -> Req t -> Req t
+prependToPathParts :: Reflex t => Behavior t (Either String String) -> Req t -> Req t
 prependToPathParts p req =
   req { reqPathParts = p : reqPathParts req }
 
-addHeader :: (ToHttpApiData a, Reflex t) => String -> Behavior t (Maybe a) -> Req t -> Req t
+addHeader :: (ToHttpApiData a, Reflex t) => String -> Behavior t (Either String a) -> Req t -> Req t
 addHeader name val req = req { headers = headers req
                                          ++ [(name, fmap (unpack . toHeader) val)]
 --                                      ++ [(name, (fmap . fmap) (decodeUtf8 . toHeader) val)]
@@ -103,39 +92,44 @@ performRequest :: forall t m.MonadWidget t m
                -> Req t
                -> Dynamic t BaseUrl
                -> Event t ()
-               -> m (Event t XhrResponse)
+               -> m (Event t XhrResponse, Event t String)
                -- -> ExceptT ServantError IO ( Int, ByteString, MediaType
                --                            , [HTTP.Header], Response ByteString)
 performRequest reqMethod req reqHost trigger = do
 
   -- Ridiculous functor-juggling! How to clean this up?
-  let t :: Behavior t [Maybe String]
+  let t :: Behavior t [Either String String]
       t = sequence $ reqPathParts req
 
-      baseUrl :: Behavior t (Maybe String)
-      baseUrl = Just . showBaseUrl <$> current reqHost
+      baseUrl :: Behavior t (Either String String)
+      baseUrl = Right . showBaseUrl <$> current reqHost
 
-      urlParts :: Behavior t (Maybe [String])
+      urlParts :: Behavior t (Either String [String])
       urlParts = fmap sequence t
 
-      urlPath :: Behavior t (Maybe String)
+      urlPath :: Behavior t (Either String String)
       urlPath = (fmap.fmap) (L.intercalate "/") urlParts
 
-      queryPartString :: (String, QueryPart t) -> Behavior t (Maybe String)
+      queryPartString :: (String, QueryPart t) -> Behavior t (Maybe (Either String String))
       queryPartString (pName, qp) = case qp of
-        QueryPartParam ps -> ffor ps $ \pStrings -> -- case null pStrings of
+        QueryPartParam p -> ffor p $ \case
+          Left e  -> Just (Left e)
+          Right a -> Just (Right $ pName ++ "=" ++ a)
+        QueryPartParams ps -> ffor ps $ \pStrings ->
           if null pStrings
           then Nothing
-          else Just (L.intercalate "&" (fmap (\p -> pName ++ '=' : p) pStrings))
+          else Just $ Right (L.intercalate "&" (fmap (\p -> pName ++ '=' : p) pStrings))
         QueryPartFlag fl -> ffor fl $ \case
-          True ->  Just pName
+          True ->  Just $ Right pName
           False -> Nothing
 
 
+      queryPartStrings :: [Behavior t (Maybe (Either String String))]
       queryPartStrings = map queryPartString (qParams req)
-      queryPartStrings' = sequence queryPartStrings :: Behavior t [Maybe String]
-      queryString :: Behavior t (Maybe String) =
-        ffor queryPartStrings' $ \qs -> Just (L.intercalate "&" (catMaybes qs))
+      queryPartStrings' = fmap (sequence . catMaybes) $ sequence queryPartStrings :: Behavior t (Either String [String])
+      queryString :: Behavior t (Either String String) =
+        ffor queryPartStrings' $ \qs -> fmap (L.intercalate "&") qs
+--        ffor queryPartStrings' $ \qs -> fmap (L.intercalate "&") (sequence qs)
       xhrUrl =  (liftA3 . liftA3) (\a p q -> a </>  if null q then p else p ++ '?' : q) baseUrl urlPath queryString
         where
           (</>) :: String -> String -> String
@@ -146,21 +140,26 @@ performRequest reqMethod req reqHost trigger = do
       xhrHeaders = sequence $ ffor (headers req) $ \(hName, hVal) -> fmap (hName,) hVal
 
 
-      mkConfigBody :: [(String,String)] -> (Maybe (BL.ByteString, String)) -> Maybe XhrRequestConfig
+      mkConfigBody :: [(String,String)] -> (Either String (BL.ByteString, String)) -> Either String XhrRequestConfig
       mkConfigBody hs rb = case rb of
-                  Nothing              -> Nothing
-                  (Just (bBytes, bCT)) ->
-                    Just $ def { _xhrRequestConfig_sendData = Just (BL.unpack bBytes)
-                               , _xhrRequestConfig_headers  =
-                                   Map.insert "Content-Type" bCT (_xhrRequestConfig_headers def)}
+                  Left e               -> Left e
+                  (Right (bBytes, bCT)) ->
+                    Right $ def { _xhrRequestConfig_sendData = Just (BL.unpack bBytes)
+                                , _xhrRequestConfig_headers  =
+                                    Map.insert "Content-Type" bCT (_xhrRequestConfig_headers def)}
 
-      xhrOpts :: Behavior t (Maybe XhrRequestConfig)
+      xhrOpts :: Behavior t (Either String XhrRequestConfig)
       xhrOpts = case reqBody req of
-        Nothing    -> fmap (\h -> Just $ def { _xhrRequestConfig_headers = Map.fromList h }) xhrHeaders
+        Nothing    -> fmap (\h -> Right $ def { _xhrRequestConfig_headers = Map.fromList h }) xhrHeaders
         Just rBody -> liftA2 mkConfigBody xhrHeaders rBody
       xhrReq = (liftA2 . liftA2) (\p opt -> XhrRequest reqMethod p opt) xhrUrl xhrOpts
 
-  performRequestAsync (fmapMaybe id $ tag xhrReq trigger)
+  let reqs    = tag xhrReq trigger
+      okReqs  = fmapMaybe (either (const Nothing) Just) reqs
+      badReqs = fmapMaybe (either Just (const Nothing)) reqs
+
+  resps <- performRequestAsync okReqs
+  return (resps, badReqs)
 
   -- let oneNamedPair :: String -> [QueryPart] -> String
   --     oneNamedPair pName ps =
@@ -183,7 +182,8 @@ performRequest reqMethod req reqHost trigger = do
   -- TODO Proxy probably not needed
 performRequestNoBody ::
   forall t m .MonadWidget t m => String -> Req t -> Dynamic t BaseUrl
-                              -> Event t () -> m (Event t (Maybe NoContent, XhrResponse))
+--                               -> Event t () -> m (Event t (Maybe NoContent, XhrResponse))
+                              -> Event t () -> m (Event t (ReqResult NoContent))
 performRequestNoBody reqMethod req reqHost trigger = do
   -- performRequest reqMethod req reqHost trigger
   undefined
@@ -191,15 +191,16 @@ performRequestNoBody reqMethod req reqHost trigger = do
 
 performRequestCT :: (MonadWidget t m, MimeUnrender ct a)
                  => Proxy ct -> String -> Req t -> Dynamic t BaseUrl
-                 -> Event t () -> m (Event t (ReqResult e a))
+                 -> Event t () -> m (Event t (ReqResult a))
 performRequestCT ct reqMethod req reqHost trigger = do
-  resp <- performRequest reqMethod req reqHost trigger
+  (resp, badReq) <- performRequest reqMethod req reqHost trigger
   let decodes = ffor resp $ \xhr ->
         ((mimeUnrender ct . BL.fromStrict . TE.encodeUtf8)
          =<< note "No body text" (_xhrResponse_responseText xhr), xhr)
-  return $ ffor decodes $ \case
-    (Right a, resp) -> ResponseSuccess a resp
-    (Left e,  resp) -> ResponseFailure e resp
+      reqs = ffor decodes $ \case
+        (Right a, resp) -> ResponseSuccess a resp
+        (Left e,  resp) -> ResponseFailure e resp
+  return $ leftmost [reqs, fmap RequestFailure badReq]
 
 note :: e -> Maybe a -> Either e a
 note e = maybe (Left e) Right


### PR DESCRIPTION
Addresses #8 

When a request is triggered there are three possible outcomes:

 - Request parameters are serialized, a valid response comes back and is decoded properly
 - Request parameters are serialized, a response comes back that can't be decoded
 - No request is sent because the state of the gui doesn't provide valid req params

Previously there was no way to tell when (3) was happening - request triggers were silently ignored.

To improve this situation, first we allow API parameters to report errors; captures become `Behavior t (Either String a)`, and QueryParam includes the ability to 'Either String' its parameter. Second, we augment the computed endpoints' return values to indicate the result of the request - one constructor for each of the possibilities listed above.