### PR TITLE
Response Headers

### DIFF
--- a/exec/API.hs
+++ b/exec/API.hs
@@ -15,6 +15,7 @@ type API = "getunit" :> Get '[JSON] ()
       :<|> "double" :> ReqBody '[JSON] Double
                     :> Post '[JSON] Double
       :<|> "a" :> "b" :> QueryFlag "gusto" :> Get '[JSON] String
+      :<|> "headertest" :> Get '[JSON] (Headers '[Header "myheader" Integer] Int)
       :<|> Raw
 
 type GET = Get '[JSON] ()

--- a/exec/Example.hs
+++ b/exec/Example.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE FlexibleContexts #-}
 
 module Main where
 
@@ -30,7 +32,7 @@ run = do
   el "br" (return ())
 
   -- Name the computed API client functions
-  let (getUnit :<|> getInt :<|> sayhi :<|> dbl :<|> multi :<|> doRaw) =
+  let (getUnit :<|> getInt :<|> sayhi :<|> dbl :<|> multi :<|> hdr :<|> doRaw) =
         client api (Proxy :: Proxy m) url
 
   elClass "div" "demo-group" $ do
@@ -86,6 +88,15 @@ run = do
     mpGo <- button "Test"
     multiResp <- multi b mpGo
     dynText =<< holdDyn "No res yet" (fmap show $ fmapMaybe reqSuccess $ multiResp)
+
+  elClass "div" "demo-group" $ do
+    text "Header test"
+    hdGo <- button "Header"
+    hdResp <- hdr hdGo
+    dynText =<< holdDyn "No res yet" (fmap (show . getHeaders . getHeadersHList) $ fmapMaybe reqSuccess $ hdResp)
+
+-- showHeader :: (GetHeaders (ls :: *)) => Headers ls a -> String
+-- showHeader hs = show (getHeaders $ getHeadersHList hs)
 
 showXhrResponse :: XhrResponse -> String
 showXhrResponse (XhrResponse stat stattxt rbmay rtmay) =

--- a/overrides-ghc.nix
+++ b/overrides-ghc.nix
@@ -6,5 +6,22 @@ in reflex-platform.ghc.override {
   overrides = self: super: {
     reflex-dom-contrib = pkgs.haskell.lib.dontCheck (self.callPackage deps/reflex-dom-contrib {});
     servant = pkgs.haskell.lib.dontCheck (self.callPackage (reflex-platform.cabal2nixResult deps/servant/servant) {});
+    servant-server = pkgs.haskell.lib.dontCheck (self.callPackage (reflex-platform.cabal2nixResult deps/servant/servant-server) {});
+    servant-docs = pkgs.haskell.lib.dontCheck (self.callPackage (reflex-platform.cabal2nixResult deps/servant/servant-docs) {});
+    servant-blaze = pkgs.haskell.lib.dontCheck (self.callPackage (reflex-platform.cabal2nixResult deps/servant/servant-blaze) {});
+
+    servant-snap = pkgs.haskell.lib.dontCheck (self.callPackage (reflex-platform.cabal2nixResult deps/servant-snap) {});
+
+    hspec-snap = pkgs.haskell.lib.dontCheck (self.callPackage (reflex-platform.cabal2nixResult deps/servant-snap/deps/hspec-snap) {});
+    snap-loader-static = pkgs.haskell.lib.dontCheck (self.callPackage (reflex-platform.cabal2nixResult deps/servant-snap/deps/snap-loader-static) {});
+    snap-loader-dynamic = pkgs.haskell.lib.dontCheck (self.callPackage (reflex-platform.cabal2nixResult deps/servant-snap/deps/snap-loader-dynamic) {});
+    snap = pkgs.haskell.lib.dontCheck (self.callPackage (reflex-platform.cabal2nixResult deps/servant-snap/deps/snap) {});
+    snap-server = pkgs.haskell.lib.dontCheck (self.callPackage (reflex-platform.cabal2nixResult deps/servant-snap/deps/snap/deps/snap-server) {});
+    snap-core = pkgs.haskell.lib.dontCheck (self.callPackage (reflex-platform.cabal2nixResult deps/servant-snap/deps/snap/deps/snap-core) {});
+    io-streams = pkgs.haskell.lib.dontCheck (self.callPackage (reflex-platform.cabal2nixResult deps/servant-snap/deps/snap/deps/io-streams) {});
+    io-streams-haproxy = pkgs.haskell.lib.dontCheck (self.callPackage (reflex-platform.cabal2nixResult deps/servant-snap/deps/snap/deps/io-streams-haproxy) {});
+    xmlhtml = pkgs.haskell.lib.dontCheck (self.callPackage (reflex-platform.cabal2nixResult deps/servant-snap/deps/snap/deps/xmlhtml) {});
+    heist = pkgs.haskell.lib.dontCheck (self.callPackage (reflex-platform.cabal2nixResult deps/servant-snap/deps/snap/deps/heist) {});
+    clock = pkgs.haskell.lib.dontCheck (self.callPackage (reflex-platform.cabal2nixResult deps/servant-snap/deps/clock) {});
   };
 }

--- a/servant-reflex.cabal
+++ b/servant-reflex.cabal
@@ -1,5 +1,5 @@
 Name: servant-reflex
-Version: 0.1
+Version: 0.2
 Synopsis: Servant reflex API generator
 Description: Servant reflex API generator
 License: AllRightsReserved
@@ -48,7 +48,7 @@ library
   default-language: Haskell2010
 
 executable example
-  build-depends: reflex, servant-reflex, base, scientific, servant, reflex-dom
+  build-depends: reflex, servant-reflex, base, ghcjs-base, scientific, servant, reflex-dom, transformers
   default-language: Haskell2010
   main-is: Example.hs
   other-modules: API

--- a/src/Servant/Common/Req.hs
+++ b/src/Servant/Common/Req.hs
@@ -44,6 +44,11 @@ data ReqResult a = ResponseSuccess a XhrResponse
                  | ResponseFailure String XhrResponse
                  | RequestFailure String
 
+instance Functor ReqResult where
+  fmap f (ResponseSuccess a xhr) = ResponseSuccess (f a) xhr
+  fmap _ (ResponseFailure s x)   = ResponseFailure s x
+  fmap _ (RequestFailure s)      = RequestFailure s
+
 reqSuccess :: ReqResult a -> Maybe a
 reqSuccess (ResponseSuccess x _) = Just x
 reqSuccess _                     = Nothing

--- a/testserver/Main.hs
+++ b/testserver/Main.hs
@@ -8,11 +8,13 @@
 import           Data.Aeson
 import           Data.Bool
 import           Data.Char (toUpper)
+import           Data.CaseInsensitive (CI(..),mk)
 import qualified Data.List as L
 import           Data.Monoid
 import           Data.Proxy
 import           Data.Text hiding (length, null, map, head, toUpper)
 import           GHC.Generics
+import           Network.HTTP.Types
 import           Snap.Http.Server
 import           Snap.Core
 import           Servant.Server.Internal.SnapShims
@@ -44,7 +46,7 @@ data App = App
 --
 -- Each handler runs in the 'ExceptT ServantErr IO' monad.
 server :: Server API (Handler App App)
-server = return () :<|> return 100 :<|> sayhi :<|> dbl :<|> multi :<|> serveDirectory "static"
+server = return () :<|> return 100 :<|> sayhi :<|> dbl :<|> multi :<|> myHeader :<|> serveDirectory "static"
   where sayhi nm greetings withGusto = case nm of
           Nothing -> return ("Sorry, who are you?" :: String)
           Just n  -> do
@@ -57,6 +59,8 @@ server = return () :<|> return 100 :<|> sayhi :<|> dbl :<|> multi :<|> serveDire
            return . modifier $ greetPart ++ n
         dbl x = return $ x * 2
         multi = return . bool "Box unchecked" "Box Checked"
+        myHeader = return (Headers 222 (buildHeadersTo [(mk "myheader" :: HeaderName,"333")]))
+          -- modifyResponse (addHeader (CI "myheader" ))
 
 -- Turn the server into a WAI app. 'serve' is provided by servant,
 -- more precisely by the Servant.Server module.

--- a/testserver/testserver.cabal
+++ b/testserver/testserver.cabal
@@ -19,6 +19,15 @@ executable back
   main-is:             Main.hs
   -- other-modules:       
   -- other-extensions:    
-  build-depends:       aeson, base >=4.8 && <4.9, snap, snap-server, snap-core, servant, servant-snap, text
+  build-depends:       aeson
+                     , base >=4.8 && <4.9
+                     , case-insensitive
+                     , http-types
+                     , snap
+                     , snap-server
+                     , snap-core
+                     , servant
+                     , servant-snap
+                     , text
   -- hs-source-dirs:      
   default-language:    Haskell2010


### PR DESCRIPTION
Proof of concept for response header parsing.

Replaced the `Reflex.Dom.Xhr.XhrRequest` and `Reflex.Dom.Xhr.XhrResponse` with `JavaScript.Web.XhrRequest.Request` and `JavaScript.Web.XhrRequest.Response a` from `ghcjs-base`, in order to access the response headers.

In the future it may be better to patch `reflex-dom` to allow access to response headers from `Reflex.Dom.Xhr.XhrResponse` (currently not supported there), because `JavaScript.Web.XhrRequest` ties us to ghcjs.

There is [one serious TODO](https://github.com/imalsogreg/servant-reflex/compare/imalsogreg:f0ffaae...imalsogreg:10c00b6#diff-b782cac567a301d00e88b37a3cacb75cR123) in this branch. Currently all response headers are retrieved and split (although only the needed ones are decoded, as we want). It may be nice to retrieve only the headers  needed by the Servant route. But I'm having a little trouble generating a list of header keys from the API type.