### PR TITLE
Actually set request headers.

### DIFF
--- a/src/Servant/Common/Req.hs
+++ b/src/Servant/Common/Req.hs
@@ -81,9 +81,7 @@ prependToPathParts p req =
 
 addHeader :: (ToHttpApiData a, Reflex t) => String -> Behavior t (Either String a) -> Req t -> Req t
 addHeader name val req = req { headers = headers req
-                                         ++ [(name, fmap (unpack . toHeader) val)]
---                                      ++ [(name, (fmap . fmap) (decodeUtf8 . toHeader) val)]
-                             }
+  ++ [(name, fmap (unpack . either (const "") toHeader) val)] }
 
 -- * performing requests
 

--- a/src/Servant/Reflex.hs
+++ b/src/Servant/Reflex.hs
@@ -186,14 +186,10 @@ instance (KnownSymbol sym, ToHttpApiData a,
   type Client t m (Header sym a :> sublayout) =
     Behavior t (Either String a) -> Client t m sublayout
 
-  clientWithRoute Proxy q req baseurl mval =
+  clientWithRoute Proxy q req baseurl eitherVal =
     clientWithRoute (Proxy :: Proxy sublayout)
                     q
-                    req
-                    -- (maybe req -- TODO Need to pass the header in
-                    --        (\value -> Servant.Common.Req.addHeader hname value req)
-                    --        mval
-                    -- )
+                    (Servant.Common.Req.addHeader hname eitherVal req)
                     baseurl
 
     where hname = symbolVal (Proxy :: Proxy sym)


### PR DESCRIPTION
Previously, the `HasClient` instance for `(Header sym a :> sublayout)` didn't actually set the request header.  This pull request adds header setting.

Additionally, it changes the behavior of `addHeader`.  `addHeader` previously took an `Either String a` and called `toHeader` on it, which resulted in the header containing the `Right` in stringified form.  This pull request sets the header without including the "right " part of the string.  In the case of a `Left`, it sets the header to "", which might or might not be reasonable behavior.  If some other behavior is desired, I'll happy change it.

Closes #20.