### PR TITLE
Add headers to requests, handling Either cases.

### DIFF
--- a/src/Servant/Reflex.hs
+++ b/src/Servant/Reflex.hs
@@ -186,10 +186,10 @@ instance (KnownSymbol sym, ToHttpApiData a,
   type Client t m (Header sym a :> sublayout) =
     Behavior t (Either String a) -> Client t m sublayout
 
-  clientWithRoute Proxy q req baseurl mval =
+  clientWithRoute Proxy q req baseurl eval =
     clientWithRoute (Proxy :: Proxy sublayout)
                     q
-                    req
+                    (Servant.Common.Req.addHeader hname eval req)
                     -- (maybe req -- TODO Need to pass the header in
                     --        (\value -> Servant.Common.Req.addHeader hname value req)
                     --        mval


### PR DESCRIPTION
Actually adds headers to requests.  Changes `headers` on `Req`s to hold
`Either String String` in case a header is invalid.  This simplifies
`addHeader`, but pushes considerable complexity into `xhrHeaders`, which
is now incomprehensible.

I haven't tested yet, since I'm having suddenly trouble building the project I'm using this for, but should be able to test shortly.

Is this the general approach you were looking for?

Closes #20.