### PR TITLE
Use stack to build with ghcjs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ log
 out
 reflex-platform
 /.stack-work/
+*.js.externs

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+all: native copy-js
+
+.PHONY: javascript copy-js native happy-hack run
+
+stackjs = stack --stack-yaml stack.ghcjs.yaml
+
+server_directory = testserver
+
+install_root := $(shell stack path --local-install-root)
+
+js_install_root := $(shell $(stackjs) path --local-install-root)
+
+hackmsg = echo "If build failed while installing 'happy', try 'make happy-hack'"
+
+happy-hack:
+	PATH=$$(dirname $$(stack exec which ghc)):$$(dirname $$(stack exec which happy)):$$PATH \
+		$(stackjs) build happy
+
+javascript:
+	@echo $(stackjs) build --install-ghc
+	@     $(stackjs) build --install-ghc || $(hackmsg)
+
+copy-js: javascript
+	cp $(js_install_root)/bin/example.jsexe/* $(server_directory)/static
+
+native:
+	stack build --install-ghc
+
+run: native copy-js
+	cd $(server_directory) && $(install_root)/bin/back

--- a/stack.ghcjs.yaml
+++ b/stack.ghcjs.yaml
@@ -1,0 +1,46 @@
+resolver: lts-7.19
+compiler: ghcjs-0.2.1.9007019_ghc-8.0.1
+compiler-check: match-exact
+
+setup-info:
+  ghcjs:
+    source:
+      ghcjs-0.2.1.9007019_ghc-8.0.1:
+           url: http://ghcjs.tolysz.org/ghc-8.0-2017-02-05-lts-7.19-9007019.tar.gz
+           sha1: d2cfc25f9cda32a25a87d9af68891b2186ee52f9
+packages:
+- '.'
+# - 'testserver'
+# - 'testdriver'
+
+- location:
+    git: https://github.com/reflex-frp/reflex
+    commit: d78ba4318c425ca9b942dc387d7c5c7ab2d2e095
+  extra-dep: true
+
+- location:
+    git: https://github.com/mokus0/dependent-sum.git
+    commit: bbc8ad3a81ea7f2b07ce7d036efd56f2e0f7c6ff
+  extra-dep: true
+
+- location:
+    git: https://github.com/afcady/reflex-dom.git
+    commit: 39b5ff23f3ae95d77c909ab3ed4bc4bd9e61f600
+  extra-dep: true
+
+- location:
+    git: https://github.com/afcady/dependent-sum-template.git
+    commit: 68fc1a90580ea8f20775491cf651eefea422212a
+  extra-dep: true
+
+- location:
+    git: https://github.com/ghcjs/ghcjs-base.git
+    commit: dd7034ef8582ea8a175a71a988393a9d1ee86d6f
+  extra-dep: true
+
+extra-deps:
+- ghcjs-dom-0.2.4.0
+- dlist-0.7.1.2
+- prim-uniq-0.1.0.1
+- ref-tf-0.4.0.1
+- zenc-0.1.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,10 @@
+resolver: lts-8.3
 flags: {}
 extra-package-dbs: []
 packages:
 - '.'
+- 'testserver'
+# - 'testdriver'
 
 - location:
     git: https://github.com/reflex-frp/reflex
@@ -40,6 +43,11 @@ packages:
     commit: 68fc1a90580ea8f20775491cf651eefea422212a
   extra-dep: true
 
+- location:
+    git: https://github.com/haskell-servant/servant-snap/
+    commit: b29e851e28f5adc1d9726e287f0691d77e854a9c
+  extra-dep: true
+
 extra-deps:
 - cpphs-1.20.4
 - directory-1.2.7.1
@@ -53,4 +61,6 @@ extra-deps:
 - vector-0.12.0.0
 - webkitgtk3-javascriptcore-0.13.2.0
 - zenc-0.1.1
-resolver: lts-8.3
+- snap-1.0.0.1
+- heist-1.0.1.0
+- map-syntax-0.2.0.2

--- a/testserver/testserver.cabal
+++ b/testserver/testserver.cabal
@@ -29,3 +29,4 @@ executable back
                      , text  >= 1.2 && < 1.3
   -- hs-source-dirs:
   default-language:    Haskell2010
+  other-modules: API


### PR DESCRIPTION
Added a separate `stack.yaml` for `ghcjs` and a `Makefile` that calls runs `stack build` twice (for backend and javascript).