### PR TITLE
Add ClientOptions to support withCredentials and request debugging

### DIFF
--- a/exec/Example.hs
+++ b/exec/Example.hs
@@ -96,14 +96,12 @@ run = mdo
   el "br" (return ())
 
   -- Name the computed API client functions
+  let tweakRequest = ClientOptions $ \r -> do
+          putStrLn ("Got req: " ++ show r)
+          return $ r & withCredentials .~ True
   let (getUnit :<|> getInt :<|> sayhi :<|> dbl
        :<|> multi :<|> qna :<|> secret :<|> doRaw) =
-        clientWithOpts api (Proxy :: Proxy m) (Proxy :: Proxy Int) url
-          (ClientOptions {
-                  optsWithCredentials = True
-                  , optsDebugRequests = \x -> putStrLn "Got a request!" >>
-                                        putStrLn (show x)
-                  })
+        clientWithOpts api (Proxy :: Proxy m) (Proxy :: Proxy Int) url tweakRequest
 
       c2 = client (Proxy :: Proxy ComprehensiveAPI) (Proxy :: Proxy m) (Proxy :: Proxy ()) url -- Just make sure this compiles for now
 

--- a/exec/Example.hs
+++ b/exec/Example.hs
@@ -98,7 +98,12 @@ run = mdo
   -- Name the computed API client functions
   let (getUnit :<|> getInt :<|> sayhi :<|> dbl
        :<|> multi :<|> qna :<|> secret :<|> doRaw) =
-        client api (Proxy :: Proxy m) (Proxy :: Proxy Int) url
+        clientWithOpts api (Proxy :: Proxy m) (Proxy :: Proxy Int) url
+          (ClientOptions {
+                  optsWithCredentials = True
+                  , optsDebugRequests = \x -> putStrLn "Got a request!" >>
+                                        putStrLn (show x)
+                  })
 
       c2 = client (Proxy :: Proxy ComprehensiveAPI) (Proxy :: Proxy m) (Proxy :: Proxy ()) url -- Just make sure this compiles for now
 

--- a/servant-reflex.cabal
+++ b/servant-reflex.cabal
@@ -1,5 +1,5 @@
 Name: servant-reflex
-Version: 0.3.1
+Version: 0.3.2
 Synopsis: Servant reflex API generator
 Description: Servant reflex API generator
 License: BSD3

--- a/servant-reflex.cabal
+++ b/servant-reflex.cabal
@@ -33,7 +33,7 @@ library
     data-default        >= 0.5  && < 0.8,
     exceptions          >= 0.8  && < 0.9,
     ghcjs-dom           >= 0.2  && < 0.10,
-    http-api-data       >= 0.2  && < 0.4,
+    http-api-data       >= 0.3.6 && < 0.4,
     http-media          >= 0.6  && < 0.7,
     jsaddle             >= 0.8  && < 0.10,
     mtl                 >= 2.2.1 && < 2.3,

--- a/src/Servant/Common/Req.hs
+++ b/src/Servant/Common/Req.hs
@@ -138,7 +138,7 @@ data Req t = Req
   }
 
 defReq :: Req t
-defReq = Req "GET" [] [] Nothing [] def Nothing -- False (\_ -> return ())
+defReq = Req "GET" [] [] Nothing [] def Nothing
 
 prependToPathParts :: Dynamic t (Either Text Text) -> Req t -> Req t
 prependToPathParts p req =
@@ -229,7 +229,7 @@ reqToReflexRequest reqMeth reqHost opts req =
                                                        , _xhrRequestConfig_password = Nothing
                                                        , _xhrRequestConfig_responseType = Nothing
                                                        , _xhrRequestConfig_sendData = ""
-                                                       , _xhrRequestConfig_withCredentials = False
+                                                       , _xhrRequestConfig_withCredentials = optsWithCredentials opts
                                                        }
         Just rBody -> liftA2 mkConfigBody xhrHeaders rBody
 

--- a/src/Servant/Reflex.hs
+++ b/src/Servant/Reflex.hs
@@ -24,9 +24,12 @@
 -- API.
 module Servant.Reflex
   ( client
+  , clientWithOpts
+  , clientWithRoute
   , BuildHeaderKeysTo(..)
   , toHeaders
-  , HasClient(..)
+  , HasClient
+  , Client
   , module Servant.Common.Req
   , module Servant.Common.BaseUrl
   ) where
@@ -65,7 +68,9 @@ import           Reflex.Dom              (Dynamic, Event, Reflex,
 import           Servant.Common.BaseUrl  (BaseUrl(..), Scheme(..), baseUrlWidget,
                                           showBaseUrl,
                                           SupportsServantReflex)
-import           Servant.Common.Req      (Req, ReqResult(..), QParam(..),
+import           Servant.Common.Req      (ClientOptions(..),
+                                          defaultClientOptions,
+                                          Req, ReqResult(..), QParam(..),
                                           QueryPart(..), addHeader, authData,
                                           defReq, evalResponse, prependToPathParts,
                                           -- performRequestCT,
@@ -75,7 +80,8 @@ import           Servant.Common.Req      (Req, ReqResult(..), QParam(..),
                                           performSomeRequestsAsync,
                                           qParamToQueryPart, reqBody,
                                           reqSuccess, reqFailure,
-                                          reqMethod, respHeaders, response,
+                                          reqMethod, respHeaders,
+                                          response,
                                           reqTag,
                                           qParams)
 
@@ -95,9 +101,24 @@ import           Servant.Common.Req      (Req, ReqResult(..), QParam(..),
 --               -> m (Event t (l, ReqResult Book)))
 -- > (getAllBooks :<|> postNewBook) = client myApi host
 -- >   where host = constDyn $ BaseUrl Http "localhost" 8080
-client :: (HasClient t m layout tag)
-       => Proxy layout -> Proxy m -> Proxy tag -> Dynamic t BaseUrl -> Client t m layout tag
-client p q t baseurl = clientWithRoute p q t defReq baseurl
+client
+    :: (HasClient t m layout tag)
+    => Proxy layout
+    -> Proxy m
+    -> Proxy tag
+    -> Dynamic t BaseUrl
+    -> Client t m layout tag
+client p q t baseurl = clientWithRoute p q t defReq baseurl defaultClientOptions
+
+clientWithOpts
+    :: (HasClient t m layout tag)
+    => Proxy layout
+    -> Proxy m
+    -> Proxy tag
+    -> Dynamic t BaseUrl
+    -> ClientOptions
+    -> Client t m layout tag
+clientWithOpts p q t baseurl = clientWithRoute p q t defReq baseurl
 
 
 -- | This class lets us define how each API combinator
@@ -105,15 +126,15 @@ client p q t baseurl = clientWithRoute p q t defReq baseurl
 -- an internal class, you can just use 'client'.
 class HasClient t m layout (tag :: *) where
   type Client t m layout tag :: *
-  clientWithRoute :: Proxy layout -> Proxy m -> Proxy tag -> Req t -> Dynamic t BaseUrl -> Client t m layout tag
+  clientWithRoute :: Proxy layout -> Proxy m -> Proxy tag -> Req t -> Dynamic t BaseUrl -> ClientOptions -> Client t m layout tag
 
 
 instance (HasClient t m a tag, HasClient t m b tag) => HasClient t m (a :<|> b) tag where
   type Client t m (a :<|> b) tag = Client t m a tag :<|> Client t m b tag
 
-  clientWithRoute Proxy q pTag req baseurl =
-    clientWithRoute (Proxy :: Proxy a) q pTag req baseurl :<|>
-    clientWithRoute (Proxy :: Proxy b) q pTag req baseurl
+  clientWithRoute Proxy q pTag req baseurl opts =
+    clientWithRoute (Proxy :: Proxy a) q pTag req baseurl opts :<|>
+    clientWithRoute (Proxy :: Proxy b) q pTag req baseurl opts
 
 
 -- Capture. Example:
@@ -134,11 +155,11 @@ instance (SupportsServantReflex t m, ToHttpApiData a, HasClient t m sublayout ta
   type Client t m (Capture capture a :> sublayout) tag =
     Dynamic t (Either Text a) -> Client t m sublayout tag
 
-  clientWithRoute Proxy q t req baseurl val =
+  clientWithRoute Proxy q t req baseurl opts val =
     clientWithRoute (Proxy :: Proxy sublayout)
                     q t
                     (prependToPathParts p req)
-                    baseurl
+                    baseurl opts
     where p = (fmap . fmap) (toUrlPiece) val
 
 
@@ -151,9 +172,8 @@ instance {-# OVERLAPPABLE #-}
     Event t tag -> m (Event t (ReqResult tag a))
     -- TODO how to access input types here?
     -- ExceptT ServantError IO a
-  clientWithRoute Proxy _ _ req baseurl trigs =
-    -- performRequestCT (Proxy :: Proxy ct) method req' baseurl trigs
-      fmap runIdentity <$> performRequestsCT (Proxy :: Proxy ct) method (constDyn $ Identity $ req') baseurl trigs
+  clientWithRoute Proxy _ _ req baseurl opts trigs =
+      fmap runIdentity <$> performRequestsCT (Proxy :: Proxy ct) method (constDyn $ Identity $ req') baseurl opts trigs
       where method = E.decodeUtf8 $ reflectMethod (Proxy :: Proxy method)
             req' = req { reqMethod = method }
 
@@ -166,8 +186,8 @@ instance {-# OVERLAPPING #-}
     Event t tag -> m (Event t (ReqResult tag NoContent))
     -- TODO: how to access input types here?
     -- ExceptT ServantError IO NoContent
-  clientWithRoute Proxy _ _ req baseurl =
-    (fmap . fmap) runIdentity . performRequestsNoBody method (constDyn $ Identity req) baseurl
+  clientWithRoute Proxy _ _ req baseurl opts =
+    (fmap . fmap) runIdentity . performRequestsNoBody method (constDyn $ Identity req) baseurl opts
       where method = E.decodeUtf8 $ reflectMethod (Proxy :: Proxy method)
 
 
@@ -203,9 +223,9 @@ instance {-# OVERLAPPABLE #-}
   ) => HasClient t m (Verb method status cts' (Headers ls a)) tag where
   type Client t m (Verb method status cts' (Headers ls a)) tag =
       Event t tag -> m (Event t (ReqResult tag (Headers ls a)))
-  clientWithRoute Proxy _ _ req baseurl trigs = do
+  clientWithRoute Proxy _ _ req baseurl opts trigs = do
     let method = E.decodeUtf8 $ reflectMethod (Proxy :: Proxy method)
-    resp <- fmap runIdentity <$> performRequestsCT (Proxy :: Proxy ct) method (constDyn $ Identity req') baseurl trigs
+    resp <- fmap runIdentity <$> performRequestsCT (Proxy :: Proxy ct) method (constDyn $ Identity req') baseurl opts trigs
     return $ toHeaders <$> resp
     where req' = req { respHeaders =
                        OnlyHeaders (Set.fromList (buildHeaderKeysTo (Proxy :: Proxy ls)))
@@ -219,9 +239,9 @@ instance {-# OVERLAPPABLE #-}
   ) => HasClient t m (Verb method status cts (Headers ls NoContent)) tag where
   type Client t m (Verb method status cts (Headers ls NoContent)) tag
     = Event t tag -> m (Event t (ReqResult tag (Headers ls NoContent)))
-  clientWithRoute Proxy _ _ req baseurl trigs = do
+  clientWithRoute Proxy _ _ req baseurl opts trigs = do
     let method = E.decodeUtf8 $ reflectMethod (Proxy :: Proxy method)
-    resp <- fmap runIdentity <$> performRequestsNoBody method (constDyn $ Identity req') baseurl trigs
+    resp <- fmap runIdentity <$> performRequestsNoBody method (constDyn $ Identity req') baseurl opts trigs
     return $ toHeaders <$> resp
     where req' = req {respHeaders =
                       OnlyHeaders (Set.fromList (buildHeaderKeysTo (Proxy :: Proxy ls)))
@@ -249,11 +269,11 @@ instance (KnownSymbol sym, ToHttpApiData a,
   type Client t m (Header sym a :> sublayout) tag =
     Dynamic t (Either Text a) -> Client t m sublayout tag
 
-  clientWithRoute Proxy q t req baseurl eVal =
+  clientWithRoute Proxy q t req baseurl opts eVal =
     clientWithRoute (Proxy :: Proxy sublayout)
                     q t
                     (Servant.Common.Req.addHeader hname eVal req)
-                    baseurl
+                    baseurl opts
     where hname = T.pack $ symbolVal (Proxy :: Proxy sym)
 
 
@@ -304,9 +324,9 @@ instance (KnownSymbol sym, ToHttpApiData a, HasClient t m sublayout tag, Reflex 
     Dynamic t (QParam a) -> Client t m sublayout tag
 
   -- if mparam = Nothing, we don't add it to the query string
-  clientWithRoute Proxy q t req baseurl mparam =
+  clientWithRoute Proxy q t req baseurl opts mparam =
     clientWithRoute (Proxy :: Proxy sublayout) q t
-      (req {qParams = paramPair : qParams req}) baseurl
+      (req {qParams = paramPair : qParams req}) baseurl opts
 
     where pname = symbolVal (Proxy :: Proxy sym)
           --p prm = QueryPartParam $ (fmap . fmap) (toQueryParam) prm
@@ -350,8 +370,8 @@ instance (KnownSymbol sym, ToHttpApiData a, HasClient t m sublayout tag, Reflex 
   type Client t m (QueryParams sym a :> sublayout) tag =
     Dynamic t [a] -> Client t m sublayout tag
 
-  clientWithRoute Proxy q t req baseurl paramlist =
-    clientWithRoute (Proxy :: Proxy sublayout) q t req' baseurl
+  clientWithRoute Proxy q t req baseurl opts paramlist =
+    clientWithRoute (Proxy :: Proxy sublayout) q t req' baseurl opts
 
       where req'    = req { qParams =  (T.pack pname, params') : qParams req }
             pname   = symbolVal (Proxy :: Proxy sym)
@@ -390,8 +410,8 @@ instance (KnownSymbol sym, HasClient t m sublayout tag, Reflex t)
   type Client t m (QueryFlag sym :> sublayout) tag =
     Dynamic t Bool -> Client t m sublayout tag
 
-  clientWithRoute Proxy q t req baseurl flag =
-    clientWithRoute (Proxy :: Proxy sublayout) q t req' baseurl
+  clientWithRoute Proxy q t req baseurl opts flag =
+    clientWithRoute (Proxy :: Proxy sublayout) q t req' baseurl opts
 
     where req'     = req { qParams = thisPair : qParams req }
           thisPair = (T.pack pName, QueryPartFlag flag) :: (Text, QueryPart t)
@@ -405,7 +425,7 @@ instance SupportsServantReflex t m => HasClient t m Raw tag where
                       -> Event t tag
                       -> m (Event t (ReqResult tag ()))
 
-  clientWithRoute _ _ _ _ baseurl xhrs triggers = do
+  clientWithRoute _ _ _ _ baseurl _ xhrs triggers = do
 
     let xhrs'   = liftA2 (\x path -> case x of
                              Left e -> Left e
@@ -447,8 +467,8 @@ instance (MimeRender ct a, HasClient t m sublayout tag, Reflex t)
   type Client t m (ReqBody (ct ': cts) a :> sublayout) tag =
     Dynamic t (Either Text a) -> Client t m sublayout tag
 
-  clientWithRoute Proxy q t req baseurl body =
-    clientWithRoute (Proxy :: Proxy sublayout) q t req' baseurl
+  clientWithRoute Proxy q t req baseurl opts body =
+    clientWithRoute (Proxy :: Proxy sublayout) q t req' baseurl opts
        where req'        = req { reqBody = bodyBytesCT }
              ctProxy     = Proxy :: Proxy ct
              ctString    = T.pack $ show $ contentType ctProxy
@@ -462,9 +482,9 @@ instance (MimeRender ct a, HasClient t m sublayout tag, Reflex t)
 instance (KnownSymbol path, HasClient t m sublayout tag, Reflex t) => HasClient t m (path :> sublayout) tag where
   type Client t m (path :> sublayout) tag = Client t m sublayout tag
 
-  clientWithRoute Proxy q t req baseurl =
+  clientWithRoute Proxy q t req baseurl opts =
      clientWithRoute (Proxy :: Proxy sublayout) q t
-                     (prependToPathParts (pure (Right $ T.pack p)) req) baseurl
+                     (prependToPathParts (pure (Right $ T.pack p)) req) baseurl opts
 
     where p = symbolVal (Proxy :: Proxy path)
 
@@ -497,8 +517,8 @@ instance (HasClient t m api tag, Reflex t)
   type Client t m (BasicAuth realm usr :> api) tag = Dynamic t (Maybe BasicAuthData)
                                                -> Client t m api tag
 
-  clientWithRoute Proxy q t req baseurl authdata =
-    clientWithRoute (Proxy :: Proxy api) q t req' baseurl
+  clientWithRoute Proxy q t req baseurl opts authdata =
+    clientWithRoute (Proxy :: Proxy api) q t req' baseurl opts
       where
         req'    = req { authData = Just authdata }
 

--- a/src/Servant/Reflex.hs
+++ b/src/Servant/Reflex.hs
@@ -30,6 +30,7 @@ module Servant.Reflex
   , toHeaders
   , HasClient
   , Client
+  , withCredentials
   , module Servant.Common.Req
   , module Servant.Common.BaseUrl
   ) where
@@ -83,7 +84,7 @@ import           Servant.Common.Req      (ClientOptions(..),
                                           reqMethod, respHeaders,
                                           response,
                                           reqTag,
-                                          qParams)
+                                          qParams, withCredentials)
 
 
 -- * Accessing APIs as a Client

--- a/src/Servant/Reflex/Multi.hs
+++ b/src/Servant/Reflex/Multi.hs
@@ -24,6 +24,9 @@ module Servant.Reflex.Multi (
     , QParam(..)
 
     -- * Access response data
+    , withCredentials
+
+    -- * Access response data
     , ReqResult(..)
     , reqSuccess
     , reqSuccess'
@@ -70,7 +73,7 @@ import           Servant.Common.Req     (ClientOptions,
                                          prependToPathParts, qParamToQueryPart,
                                          qParams, reqBody, reqFailure,
                                          reqMethod, reqSuccess, reqSuccess',
-                                         respHeaders, response)
+                                         respHeaders, response, withCredentials)
 import           Servant.Reflex         (BuildHeaderKeysTo (..), toHeaders)
 
 

--- a/src/Servant/Reflex/Multi.hs
+++ b/src/Servant/Reflex/Multi.hs
@@ -307,10 +307,10 @@ instance (SupportsServantReflex t m,
                                  -> Event t tag
                                  -> m (Event t (f (ReqResult tag ())))
 
-  clientWithRouteMulti _ _ _ _ _ _ _ rawReqs triggers = do
+  clientWithRouteMulti _ _ _ _ _ _ opts rawReqs triggers = do
     let rawReqs' = sequence rawReqs :: Dynamic t (f (Either Text (XhrRequest ())))
         rawReqs'' = attachPromptlyDynWith (\fxhr t -> Compose (t, fxhr)) rawReqs' triggers
-    resps <- fmap (fmap aux . sequenceA . getCompose) <$> performSomeRequestsAsync rawReqs''
+    resps <- fmap (fmap aux . sequenceA . getCompose) <$> performSomeRequestsAsync opts rawReqs''
     return resps
     where
       aux (tag, Right r) = ResponseSuccess tag () r


### PR DESCRIPTION
Add a new `ClientOptions` type and `clientWithOpts` functions.

The options support user's ability to set the `withCredentials` bit in xhr requests, and to choose a request debugging function that runs in `JSM`.

Addresses #46 and #45 

RFC @3noch and @NorfairKing what do you think?