### PR TITLE
withCredentials is already exported

### DIFF
--- a/src/Servant/Reflex.hs
+++ b/src/Servant/Reflex.hs
@@ -30,7 +30,6 @@ module Servant.Reflex
   , toHeaders
   , HasClient
   , Client
-  , withCredentials
   , module Servant.Common.Req
   , module Servant.Common.BaseUrl
   ) where


### PR DESCRIPTION
`withCredentials` is re-exported by `module Servant.Common.Req`. Having both triggers a duplicate-exports warning.