### PR TITLE
Treat HTTP response statuses less than 200 as errors

### DIFF
--- a/src/Servant/Common/Req.hs
+++ b/src/Servant/Common/Req.hs
@@ -380,7 +380,8 @@ evalResponse
     -> (tag, XhrResponse)
     -> ReqResult tag a
 evalResponse decode (tag, xhr) =
-    let okStatus   = _xhrResponse_status xhr < 400
+    let status = _xhrResponse_status xhr
+        okStatus = status >= 200 && status < 400
         errMsg = fromMaybe
             ("Empty response with error code " <>
                 T.pack (show $ _xhrResponse_status xhr))


### PR DESCRIPTION
In particular, browsers seem to use status 0 for errors.