### PR TITLE
Increase some version ranges to allow building with new reflex-platform

### DIFF
--- a/servant-reflex.cabal
+++ b/servant-reflex.cabal
@@ -26,12 +26,12 @@ library
 
   hs-source-dirs: src
   build-depends:
-    base                >= 4.8  && < 4.10,
+    base                >= 4.8  && < 5,
     bytestring          >= 0.10 && < 0.11,
     case-insensitive    >= 1.2.0.4 && < 1.3,
     containers          >= 0.5.6   && < 0.6,
     data-default        >= 0.5  && < 0.8,
-    exceptions          >= 0.8  && < 0.9,
+    exceptions          >= 0.8  && < 0.11,
     ghcjs-dom           >= 0.2  && < 0.10,
     http-api-data       >= 0.3.6 && < 0.4,
     http-media          >= 0.6  && < 0.8,

--- a/servant-reflex.cabal
+++ b/servant-reflex.cabal
@@ -41,7 +41,7 @@ library
     reflex              >= 0.5  && < 0.6,
     reflex-dom-core     == 0.4  && < 0.5,
     safe                >= 0.3.9 && < 0.4,
-    servant             >= 0.12  && < 0.15,
+    servant             >= 0.8  && < 0.15,
     servant-auth        >= 0.2.1 && < 0.4,
     string-conversions  >= 0.4  && < 0.5,
     text                >= 1.2  && < 1.3,

--- a/servant-reflex.cabal
+++ b/servant-reflex.cabal
@@ -41,7 +41,7 @@ library
     reflex              >= 0.5  && < 0.6,
     reflex-dom-core     == 0.4  && < 0.5,
     safe                >= 0.3.9 && < 0.4,
-    servant             >= 0.8  && < 0.13,
+    servant             >= 0.12  && < 0.15,
     servant-auth        >= 0.2.1 && < 0.4,
     string-conversions  >= 0.4  && < 0.5,
     text                >= 1.2  && < 1.3,


### PR DESCRIPTION
 (which uses ghc8.4)