### PR TITLE
Add Response handler for refresh on client errors

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,28 +1,20 @@
-{ mkDerivation, aeson, base, bytestring, case-insensitive
-, containers, data-default, exceptions, ghcjs-dom, http-api-data
-, http-media, jsaddle, mtl, network-uri, reflex, reflex-dom
-, reflex-dom-core, safe, scientific, servant, servant-auth, stdenv
+{ mkDerivation, base, bytestring, case-insensitive, containers
+, data-default, exceptions, ghcjs-dom, http-api-data, http-media
+, jsaddle, jsaddle-dom, mtl, network-uri, reflex, reflex-dom
+, reflex-dom-core, safe, servant, servant-auth, stdenv
 , string-conversions, text, transformers
 }:
 mkDerivation {
   pname = "servant-reflex";
   version = "0.3.4";
-  src = builtins.filterSource
-        (path: type:
-        baseNameOf path != "result"
-        && baseNameOf path != "nix" 
-        ) ./.;
-  configureFlags = [ "-fexample" ];
+  src = ./.;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
     base bytestring case-insensitive containers data-default exceptions
-    ghcjs-dom http-api-data http-media jsaddle mtl network-uri reflex
-    reflex-dom-core safe servant servant-auth string-conversions text
-    transformers
-  ];
-  executableHaskellDepends = [
-    aeson base reflex reflex-dom scientific servant text
+    ghcjs-dom http-api-data http-media jsaddle jsaddle-dom mtl
+    network-uri reflex reflex-dom reflex-dom-core safe servant
+    servant-auth string-conversions text transformers
   ];
   description = "Servant reflex API generator";
   license = stdenv.lib.licenses.bsd3;

--- a/default.nix
+++ b/default.nix
@@ -18,4 +18,6 @@ mkDerivation {
   ];
   description = "Servant reflex API generator";
   license = stdenv.lib.licenses.bsd3;
+  configureFlags = [ "-fexample" ];
+
 }

--- a/servant-reflex.cabal
+++ b/servant-reflex.cabal
@@ -18,6 +18,7 @@ Flag Example
 library
   exposed-modules:
     Servant.Reflex
+    Servant.Reflex.Response
     Servant.Reflex.Multi
 
   other-modules:
@@ -45,7 +46,9 @@ library
     servant-auth        >= 0.2.1 && < 0.4,
     string-conversions  >= 0.4  && < 0.5,
     text                >= 1.2  && < 1.3,
-    transformers        >= 0.4  && < 0.6
+    transformers        >= 0.4  && < 0.6,
+    reflex-dom          >= 0.4  && < 0.5,
+    jsaddle-dom         >= 0.9.2.0 && < 0.10
 
   ghc-options: -Wall -fwarn-tabs -funbox-strict-fields -O2
 

--- a/src/Servant/Reflex/Response.hs
+++ b/src/Servant/Reflex/Response.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE ConstraintKinds   #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Response handlers
+module Servant.Reflex.Response
+  ( reloadOnAPIError
+  , RefreshSupport
+  ) where
+
+import           Control.Monad               (join, void)
+import qualified Data.Text                   as Text
+import           JSDOM                       (currentDocument)
+import           JSDOM.Generated.Document    (getLocation)
+import           JSDOM.Types                 (Location, liftDOM)
+import           Language.Javascript.JSaddle (MonadJSM, ( # ))
+import           Reflex
+import           Reflex.Dom
+import           Servant.Reflex
+
+is4xx :: ReqResult () a -> Bool
+is4xx = maybe False (\req -> (_xhrResponse_status req < fromInteger 500) && (_xhrResponse_status req >= 400)) . response
+
+isDecodeError  :: ReqResult () a -> Bool -- TODO find a better way of detecting this, this seems dumb
+isDecodeError  =
+  maybe False (Text.isInfixOf "Error in $") . reqFailure
+
+-- | Alias for constraints that can refresh
+type RefreshSupport t m = (MonadJSM m, MonadHold t m, DomBuilder t m, SupportsServantReflex t m)
+
+-- | Reloads page and clears the cache on any 4xx response or on any
+--   decoding errors.
+--   Most endpoints want to have this.
+--   These errors mean the client code is probably outdated.
+--   If so a clear cache refresh will fix the issue.
+--   We no longer care about the JS growing stale, any 4xx response will just refresh it.
+--   It also saves time in that we don't have to bother presenting good error messages for 4xx respones.
+--   The tradeoff is that our api should only return a 4xx if it thinks the client is broken.
+--   If developer wants to show a serious error message to the user he shouldn't rely on status codes
+--   anyway because they're not type safe (in servant).
+--   Status codes also don't provide good user experience,
+--   *or* dev experience. A code is simply not human friendly.
+reloadOnAPIError :: (MonadJSM m, RefreshSupport t m) => Event t (ReqResult () a) -> m (Event t (ReqResult () a))
+reloadOnAPIError reqResult = do
+  void $ widgetHold blank $ ffor reqResult $
+    \req -> if is4xx req || isDecodeError req then clearCacheReload else pure ()
+  pure reqResult
+
+-- | <https://developer.mozilla.org/en-US/docs/Web/API/Location.reload Mozilla Location.reload documentation>
+reload' :: MonadJSM m => Location -> Bool -> m ()
+reload' self bool = liftDOM $ void $ self # funName $ bool
+  where
+    funName :: String
+    funName = "reload"
+
+-- | Refresh and clear the browser cache, eg all assets will be reloaded.
+--   this could be used for example once you received a client error,
+--   it probably means you've outdated code.
+clearCacheReload :: MonadJSM m => m ()
+clearCacheReload = do
+      mayWin <- currentDocument
+      loc <- sequence $ getLocation <$> mayWin
+      maybe (pure ()) (flip reload' True) $ join loc


### PR DESCRIPTION
I'm pretty sure this is useful to other people.

If you attach this response handler it'll do a clear cache refresh on client errors or decoding errors.
This will fix the client if it's outdated (which is the most likely case), or if his session is expired the app state resets.

This won't work for endpoints who have reflex logic build on 4xx status codes,
but my thesis is that haskell developers don't want to do this because status codes aren't really type safe (in servant all status codes are always possible, you can't restrict them with types).