### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,16 @@
 language: nix
-nix: 2.1.1
+nix: 2.3.6
 sudo: require
 
-install:
+before_install:
   - sudo cp -rT $TRAVIS_BUILD_DIR/nix /etc/nix
 
 before_script:
+  - sudo systemctl restart nix-daemon.service
   - git config --global user.email "travis-ci@example.com"
   - git config --global user.name "Travis-CI"
 
 script:
-  - nix-env -iA cachix -f https://cachix.org/api/v1/install
-  - cachix use imalsogreg
   - nix-build travis.nix -A build
   - nix-build travis.nix -A testserver
   - nix-build travis.nix -A testresults

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,11 @@
+0.3.5
+-----
+
+ - Require reflex-dom-core >= 0.6 (for internal handling of case-insensitive headers)
+ - Require servant >= 0.16
+ - Eliminate use of deprecated widgets from reflex-dom-core
+ - Bump the version of reflex-platform used in nix-shell and test suite
+
 0.3.4
 -----
 

--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,7 @@
 }:
 mkDerivation {
   pname = "servant-reflex";
-  version = "0.3.4";
+  version = "0.3.5";
   src = builtins.filterSource
         (path: type:
         baseNameOf path != "result"

--- a/nix/nix.conf
+++ b/nix/nix.conf
@@ -1,2 +1,3 @@
-substituters = https://cache.nixos.org https://nixcache.reflex-frp.org
+substituters = https://cache.nixos.org/ https://nixcache.reflex-frp.org/
 trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= ryantrinkle.com-1:JJiAKaRv9mWgpVAz8dwewnZe0AzzEAzPkagE9SP5NWI=
+trusted-users = travis

--- a/nix/reflex-platform.nix
+++ b/nix/reflex-platform.nix
@@ -1,7 +1,7 @@
 let
-  rev = "a15d3a2411e7ca7d4ee4853b57c72fe83faee272";
+  rev = "df0bdcca5eb2a3236ec0496e4430d91876b29cf5";
 in import (builtins.fetchTarball
   {
     url = "https://github.com/reflex-frp/reflex-platform/archive/${rev}.tar.gz";
-    sha256 = "1dsvw0lah7761vndip1hqal4fjpjv84ravinnfhy83jgfav5ivna";
+    sha256 = "1ja3vkq9px8f9iyiazq44mamaahgiphi9l236pvzbl5jvhi5c4qr";
   }) {}

--- a/nix/servant-snap.nix
+++ b/nix/servant-snap.nix
@@ -1,9 +1,7 @@
-# Servant-snap is stuck a bit behind atm. But we have a fork that mostly works
-# except for streaming, which is good enough for this test server. See:
-# https://github.com/haskell-servant/servant-snap/issues/20
+# Servant-snap is marked broken in nixpkgs
 { nixpkgs ? import <nixpkgs> {}}: self: super:
 self.callCabal2nix "servant-snap" (nixpkgs.fetchgit {
-  url    = "https://github.com/antislava/servant-snap.git";
-  rev    = "fc9658e8f52ebce9e4f304ea0c6705d697d4fa84";
-  sha256 = "0zlipmx1fb73mhpnndwmdmigxxrsdnsnb1157pgsrxpx89l9pjig";
+  url    = "https://github.com/haskell-servant/servant-snap.git";
+  rev    = "af5172a6de5bb2a07eb1bf4c85952075ec6ecdf3";
+  sha256 = "sha256-fzzQGwG8Ko72OO/kwLMG52eNZSt3F2dxhNgM9gaO4yQ=";
 }) {}

--- a/servant-reflex.cabal
+++ b/servant-reflex.cabal
@@ -1,5 +1,5 @@
 Name: servant-reflex
-Version: 0.3.4
+Version: 0.3.5
 Synopsis: servant API generator for reflex apps
 Description: Generate reflex-compatible client functions from servant API descriptions
 License: BSD3
@@ -36,10 +36,10 @@ library
     jsaddle             >= 0.8  && < 0.10,
     mtl                 >= 2.2.1 && < 2.3,
     network-uri         >= 2.6  && < 2.7,
-    reflex              >= 0.5  && < 0.7,
-    reflex-dom-core     >= 0.4  && < 0.6,
+    reflex              >= 0.5  && < 0.8,
+    reflex-dom-core     >= 0.6  && < 0.7,
     safe                >= 0.3.9 && < 0.4,
-    servant             >= 0.8  && < 0.18,
+    servant             >= 0.16  && < 0.18,
     servant-auth        >= 0.2.1 && < 0.4,
     string-conversions  >= 0.4  && < 0.5,
     text                >= 1.2  && < 1.3,
@@ -54,7 +54,15 @@ executable example
     buildable: True
   else
     buildable: False
-  build-depends: aeson, reflex, servant-reflex, base, scientific, servant, reflex-dom-core, text
+  build-depends:
+    aeson,
+    reflex,
+    servant-reflex,
+    base,
+    scientific,
+    servant,
+    reflex-dom-core,
+    text
   default-language: Haskell2010
   main-is: Example.hs
   other-modules: API

--- a/src/Servant/Common/BaseUrl.hs
+++ b/src/Servant/Common/BaseUrl.hs
@@ -85,15 +85,14 @@ baseUrlWidget = elClass "div" "base-url" $ do
   where pathWidget :: m (Dynamic t BaseUrl)
         pathWidget = do
           text "Url base path"
-          t <- textInput (def {_textInputConfig_attributes =
-                          constDyn ("placeholder" =: "/a/b")})
+          t <- inputElement def
           return $ BasePath <$> value t
         fullUrlWidget :: m (Dynamic t BaseUrl)
         fullUrlWidget = do
           schm <- dropdown Https (constDyn $ Https =: "https" <> Http =: "http") def
-          srv  <- textInput def {_textInputConfig_attributes = constDyn $ "placeholder" =: "example.com"}
+          srv  <- inputElement def
           text ":"
-          prt  <- textInput def { _textInputConfig_attributes = constDyn $ "placeholder" =: "80"}
+          prt  <- inputElement def
           port :: Dynamic t Int <- holdDyn 80 (fmapMaybe (readMaybe . T.unpack) $ updated (value prt))
-          path <- textInput def { _textInputConfig_attributes = constDyn $ "placeholder" =: "a/b" }
+          path <- inputElement def
           return $ BaseFullUrl <$> value schm <*> value srv <*> port <*> value path

--- a/src/Servant/Reflex.hs
+++ b/src/Servant/Reflex.hs
@@ -42,7 +42,7 @@ import           Control.Applicative
 import           Data.Monoid             ((<>))
 import qualified Data.Set                as Set
 import qualified Data.Text.Encoding      as E
-import           Data.CaseInsensitive    (mk)
+import qualified Data.CaseInsensitive    as CI
 import           Data.Functor.Identity
 import           Data.Proxy              (Proxy (..))
 import qualified Data.Map                as Map
@@ -226,22 +226,26 @@ instance {-# OVERLAPPING #-}
 
 toHeaders :: BuildHeadersTo ls => ReqResult tag a -> ReqResult tag (Headers ls a)
 toHeaders r =
-  let toBS = E.encodeUtf8
-      hdrs = maybe []
-                   (\xhr -> fmap (\(h,v) -> (mk (toBS h), toBS v))
+  let hdrs = maybe []
+                   (\xhr -> fmap (\(h,v) -> (CI.map E.encodeUtf8 h, E.encodeUtf8 v))
                      (Map.toList $ _xhrResponse_headers xhr))
                    (response r)
   in  ffor r $ \a -> Headers {getResponse = a ,getHeadersHList = buildHeadersTo hdrs}
 
+
 class BuildHeaderKeysTo hs where
-  buildHeaderKeysTo :: Proxy hs -> [T.Text]
+  buildHeaderKeysTo :: Proxy hs -> [CI.CI T.Text]
 
 instance {-# OVERLAPPABLE #-} BuildHeaderKeysTo '[]
   where buildHeaderKeysTo _ = []
 
 instance {-# OVERLAPPABLE #-} (BuildHeaderKeysTo xs, KnownSymbol h)
   => BuildHeaderKeysTo ((Header h v) ': xs) where
-  buildHeaderKeysTo _ = T.pack (symbolVal (Proxy :: Proxy h)) : buildHeaderKeysTo (Proxy :: Proxy xs)
+  buildHeaderKeysTo _ =
+    let
+      thisKey = CI.mk $ T.pack (symbolVal (Proxy :: Proxy h))
+    in thisKey : buildHeaderKeysTo (Proxy :: Proxy xs)
+
 
 -- HEADERS Verb (Content) --
 -- Headers combinator not treated in fully general case,

--- a/testserver/testserver.cabal
+++ b/testserver/testserver.cabal
@@ -19,13 +19,13 @@ executable back
   main-is:             Main.hs
   -- other-modules:
   -- other-extensions:
-  build-depends:       aeson >= 0.9 && < 1.4
-                     , base >=4.8 && <4.12
+  build-depends:       aeson >= 0.9 && < 1.5
+                     , base >=4.8 && < 5
                      , mtl
                      , snap >= 1.0 && < 1.2
                      , snap-server  >= 1.0 && < 1.2
                      , snap-core  >= 1.0 && < 1.1
-                     , servant >= 0.8 && < 0.15
+                     , servant >= 0.16 && < 0.18
                      , servant-snap >= 0.8 && < 0.9
                      , text  >= 1.0 && < 1.3
   -- hs-source-dirs:


### PR DESCRIPTION
 - Require reflex-dom-core >= 0.6 (for internal handling of case-insensitive headers)
 - Require servant >= 0.16
 - Eliminate use of deprecated widgets from reflex-dom-core
 - Bump the version of reflex-platform used in nix-shell and test suite
