### PR TITLE
use a mainWidget that works with ghc and ghcjs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,6 @@ before_script:
 
 script:
   - nix-build travis.nix -A build
+  - nix-build travis.nix -A buildGhc
   - nix-build travis.nix -A testserver
   - nix-build travis.nix -A testresults

--- a/default.nix
+++ b/default.nix
@@ -1,28 +1,20 @@
-{ mkDerivation, aeson, base, bytestring, case-insensitive
-, containers, data-default, exceptions, ghcjs-dom, http-api-data
-, http-media, jsaddle, mtl, network-uri, reflex, reflex-dom-core
-, safe, scientific, servant, servant-auth, stdenv
-, string-conversions, text, transformers
+{ mkDerivation, base, bytestring, case-insensitive, containers
+, data-default, exceptions, ghcjs-dom, http-api-data, http-media
+, jsaddle, mtl, network-uri, reflex, reflex-dom, reflex-dom-core
+, safe, servant, servant-auth, stdenv, string-conversions, text
+, transformers
 }:
 mkDerivation {
   pname = "servant-reflex";
-  version = "0.3.5";
-  src = builtins.filterSource
-        (path: type:
-        baseNameOf path != "result"
-        && baseNameOf path != "nix"
-        ) ./.;
-  configureFlags = [ "-fexample" ];
+  version = "0.3.6";
+  src = ./.;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
     base bytestring case-insensitive containers data-default exceptions
     ghcjs-dom http-api-data http-media jsaddle mtl network-uri reflex
-    reflex-dom-core safe servant servant-auth string-conversions text
-    transformers
-  ];
-  executableHaskellDepends = [
-    aeson base reflex reflex-dom-core scientific servant text
+    reflex-dom reflex-dom-core safe servant servant-auth string-conversions
+    text transformers
   ];
   description = "servant API generator for reflex apps";
   license = stdenv.lib.licenses.bsd3;

--- a/exec/Example.hs
+++ b/exec/Example.hs
@@ -21,7 +21,8 @@ import Servant.API
 import API
 import Data.Proxy
 import Text.Read (readMaybe)
-import Reflex.Dom.Core hiding (run)
+import Reflex.Dom.Core hiding (run, mainWidget)
+import Reflex.Dom (mainWidget)
 ------------------------------------------------------------------------------
 import Servant.Reflex
 import Servant.Reflex.Multi

--- a/servant-reflex.cabal
+++ b/servant-reflex.cabal
@@ -61,6 +61,7 @@ executable example
     base,
     scientific,
     servant,
+    reflex-dom,
     reflex-dom-core,
     text
   default-language: Haskell2010

--- a/travis.nix
+++ b/travis.nix
@@ -48,6 +48,7 @@ in
     inherit reflexPlatform ghcPkgs ghcjsPkgs;
 
     build       = ghcjsPkgs.servant-reflex;
+    buildGhc    = ghcPkgs.servant-reflex;
     testserver  = ghcPkgs.testserver;
     testdriver  = ghcPkgs.testdriver;
     inherit testresults;


### PR DESCRIPTION
This PR addresses #106 by using `mainWidget` from `Reflex.Dom` instead of the one from `Reflex.Dom.Main`. The one in `Reflex.Dom` runs in IO and seems to typecheck in more contexts than the one from `Reflex.Dom.Main`.

We use [this](https://hackage.haskell.org/package/reflex-dom-0.6.1.0/docs/Reflex-Dom-Internal.html#v:mainWidget) rather than [this](https://hackage.haskell.org/package/reflex-dom-core-0.6.1.0/docs/Reflex-Dom-Main.html#v:mainWidget).