### PR TITLE
simplistic HasClient for servant's AuthProtect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ log
 *.stats
 out
 /.stack-work/
+dist-newstyle/


### PR DESCRIPTION
this is a simplistic implementation of a `HasClient` instance for servant's `AuthProtect` combinator.

It assumes you want to pass the "general authentication" data via the Authorization header.

Also, there is a somewhat ugly detail. GHC's type families do not support rank-2-types. Therefore, the client has to provide that same authorization data as `Text` instead of some `forall a. ToHttpApiData a`. `Text` being the most general type for this purpose that I can think of.